### PR TITLE
feat: update leitlearn article

### DIFF
--- a/components/Navbar/Navbar.tsx
+++ b/components/Navbar/Navbar.tsx
@@ -16,7 +16,7 @@ const Navbar = async () => {
 
     const banner = {
         title: t("bannerTitle"),
-        link: "/blog/leitlearn-announcement",
+        link: "https://leitlearn.com",
     };
 
     return (

--- a/content/blog/how-i-made-leitlearn.mdx
+++ b/content/blog/how-i-made-leitlearn.mdx
@@ -52,4 +52,8 @@ So, here’s a look at some of the custom UI components I built, even if they’
 ![Leitlearn Components](https://assets.6ix.fr/portfolio/blog/leitlearn-components.avif)  
 *Main UI components of Leitlearn (Duolingo inspiration)*
 
-**Leitlearn Lite will be available on June 1st at [Leitlearn.com](https://leitlearn.com)!**
+You can check out all demo components at [Leitlearn.com/components](https://leitlearn.com/components)
+
+**Leitlearn Lite is available at [Leitlearn.com](https://leitlearn.com)!**
+
+Thanks to [Leo Trux](https://leotrux.fr) and [Aiman Manchout](https://aiman.dev) for their help on user sessions, translation and toasts.

--- a/locales/lang/de.ts
+++ b/locales/lang/de.ts
@@ -1,7 +1,7 @@
 export default {
     hello: 'Hallo',
     navbar: {
-        bannerTitle: "Leitlearn Ankündigung"
+        bannerTitle: "Leitlearn ist verfügbar !",
     },
     sections: {
         greeting: {

--- a/locales/lang/en.ts
+++ b/locales/lang/en.ts
@@ -1,7 +1,7 @@
 export default {
     hello: 'Hello',
     navbar: {
-        bannerTitle: "Leitlearn announcement"
+        bannerTitle: "Leitlearn is available !",
     },
     sections: {
         greeting: {

--- a/locales/lang/es.ts
+++ b/locales/lang/es.ts
@@ -1,7 +1,7 @@
 export default {
     hello: 'Hola',
     navbar: {
-        bannerTitle: "Anuncio de Leitlearn"
+        bannerTitle: "Leitlearn está disponible !",
     },
     sections: {
         greeting: {

--- a/locales/lang/fr.ts
+++ b/locales/lang/fr.ts
@@ -1,7 +1,7 @@
 export default {
     hello: 'Bonjour',
     navbar: {
-        bannerTitle: "Révélation de Leitlearn"
+        bannerTitle: "Leitlearn est disponible !",
     },
     sections: {
         greeting: {


### PR DESCRIPTION
This pull request updates the `Leitlearn` project to reflect its availability and enhances user-facing content across multiple areas. The most important changes include updating the banner link and title, revising blog content, and localizing the banner title in multiple languages.

### Updates to the banner:

* [`components/Navbar/Navbar.tsx`](diffhunk://#diff-91565ee48a13613defa2e718c945c8c5d5816a096ebab998faab91286851c1fbL19-R19): Updated the banner link from a blog announcement to the main `Leitlearn` website (`https://leitlearn.com`).
* `locales/lang/en.ts`, `locales/lang/de.ts`, `locales/lang/es.ts`, `locales/lang/fr.ts`: Updated the banner title in English, German, Spanish, and French to announce the availability of `Leitlearn`. [[1]](diffhunk://#diff-4cc8e640650f6f55388788ba720db4904a12b0b948f731b7bee69a2dd3cd7de6L4-R4) [[2]](diffhunk://#diff-d2ba3691080306ae75686932b9d7daddc875db2653f1bf0575798b1b30574780L4-R4) [[3]](diffhunk://#diff-f7dac4eb4b8df9b1a3b12f425e5d528bb597ba5ee47c735affa791b54e7fa5bdL4-R4) [[4]](diffhunk://#diff-cb56b5c86b9a8cfaac06a45e537fda87c6b69ece2c284cfcafce50e66e5c9457L4-R4)

### Blog content improvements:

* [`content/blog/how-i-made-leitlearn.mdx`](diffhunk://#diff-c4dc02ee61e680ecad3c69e90582d690a660adeb03abb7deda3aba1ef81bb485L55-R59): Updated the blog to include a link to the demo components page, revised the announcement to reflect that `Leitlearn Lite` is now available, and added acknowledgments for contributors.