### PR TITLE
feat: update leitlearn announcement

### DIFF
--- a/components/Posts/Posts.styles.ts
+++ b/components/Posts/Posts.styles.ts
@@ -58,6 +58,7 @@ export const PostContent = styled.div`
     }
 
     em {
+        font-size: 0.9rem;
         font-style: italic;
     }
 `;

--- a/content/blog/leitlearn-beta-is-available.mdx
+++ b/content/blog/leitlearn-beta-is-available.mdx
@@ -1,6 +1,6 @@
 export const metadata = {
-  title: "How I Made Leitlearn (Lite)",
-  description: "Discover the story behind Leitlearn Lite: a free, streamlined flashcard app with Leitner revision, available June 1st on Leitlearn.com.",
+  title: "Leitlearn Beta is available",
+  description: "Discover the story behind Leitlearn Beta: a free, streamlined flashcard app with Leitner revision, available now on Leitlearn.com.",
   image: "https://assets.6ix.fr/portfolio/blog/leitlearn-components.avif",
   date: "May 20, 2025",
   author: [
@@ -8,13 +8,13 @@ export const metadata = {
   ],
 };
 
-After announcing the return of Leitlearn in January 2025, I quickly realized that my personal time was limited.  
+After announcing the return of Leitlearn in January 2025, I quickly realized that my personal time was limited.
 
-However, I didn’t want to abandon the Leitlearn project, which I had already invested so much energy into. 
+Still, I didn’t want to put the Leitlearn project on hold, especially after all the energy I had already invested.
 
-That’s why I decided to release a **Leitlearn Lite** version, offering the core features in a streamlined package.
+That’s why I’ve decided to release a beta version of Leitlearn — to provide a functional and usable foundation from the start, with plans to gradually add the remaining features in the future.
 
-## What’s Included in Leitlearn Lite
+## What’s Included in Leitlearn Beta
 
 - **Authentication** with email or Google
 - **Flashcard creation** with cover images via the Unsplash API
@@ -22,15 +22,15 @@ That’s why I decided to release a **Leitlearn Lite** version, offering the cor
 - **Leitner revision system** for spaced repetition
 - **Express mode** to allow immediate review sessions without waiting
 
-![Leitlearn Lite Dashboard](https://assets.6ix.fr/portfolio/blog/leitlearn-lite-dashboard.avif)  
-*Example 1: Leitlearn Lite dashboard*
+![Leitlearn Beta Dashboard](https://assets.6ix.fr/portfolio/blog/leitlearn-lite-dashboard.avif)  
+*Example 1: Leitlearn Beta dashboard*
 
-![Leitlearn Lite Deck Edition](https://assets.6ix.fr/portfolio/blog/leitlearn-lite-deck-edit.avif)  
+![Leitlearn Beta Deck Edition](https://assets.6ix.fr/portfolio/blog/leitlearn-lite-deck-edit.avif)  
 *Example 2: Editing an existing deck*
 
 ## What’s Missing
 
-Some features announced for the full version are not included in Lite:
+Some features announced for the full version are not included in the Beta:
 
 - **Leitlearn AI**
 - **Social features**
@@ -54,6 +54,6 @@ So, here’s a look at some of the custom UI components I built, even if they’
 
 You can check out all demo components at [Leitlearn.com/components](https://leitlearn.com/components)
 
-**Leitlearn Lite is available at [Leitlearn.com](https://leitlearn.com)!**
+**Leitlearn Beta is available at [Leitlearn.com](https://leitlearn.com)!**
 
 Thanks to [Leo Trux](https://leotrux.fr) and [Aiman Manchout](https://aiman.dev) for their help on user sessions, translation and toasts.

--- a/locales/lang/de.ts
+++ b/locales/lang/de.ts
@@ -1,7 +1,7 @@
 export default {
     hello: 'Hallo',
     navbar: {
-        bannerTitle: "Leitlearn ist verfügbar !",
+        bannerTitle: "Leitlearn Beta ist verfügbar !",
     },
     sections: {
         greeting: {

--- a/locales/lang/en.ts
+++ b/locales/lang/en.ts
@@ -1,7 +1,7 @@
 export default {
     hello: 'Hello',
     navbar: {
-        bannerTitle: "Leitlearn is available !",
+        bannerTitle: "Leitlearn Beta is available !",
     },
     sections: {
         greeting: {

--- a/locales/lang/es.ts
+++ b/locales/lang/es.ts
@@ -1,7 +1,7 @@
 export default {
     hello: 'Hola',
     navbar: {
-        bannerTitle: "Leitlearn está disponible !",
+        bannerTitle: "Leitlearn Beta está disponible !",
     },
     sections: {
         greeting: {

--- a/locales/lang/fr.ts
+++ b/locales/lang/fr.ts
@@ -1,7 +1,7 @@
 export default {
     hello: 'Bonjour',
     navbar: {
-        bannerTitle: "Leitlearn est disponible !",
+        bannerTitle: "Leitlearn Beta est disponible !",
     },
     sections: {
         greeting: {


### PR DESCRIPTION
This pull request includes updates to reflect the transition of the Leitlearn project from "Lite" to "Beta" across multiple files, along with a small style adjustment in the `PostContent` component.

### Content and Localization Updates:
* Renamed `content/blog/how-i-made-leitlearn.mdx` to `content/blog/leitlearn-beta-is-available.mdx` and updated the title, description, and content to reflect the new "Beta" version of Leitlearn. This includes changes to headings, feature descriptions, and image captions. [[1]](diffhunk://#diff-41b4c34feec6d2af5b191c71f44d4646a2228d4e8cfa56832810891e4470457dL2-R3) [[2]](diffhunk://#diff-41b4c34feec6d2af5b191c71f44d4646a2228d4e8cfa56832810891e4470457dL13-R33) [[3]](diffhunk://#diff-41b4c34feec6d2af5b191c71f44d4646a2228d4e8cfa56832810891e4470457dL57-R57)
* Updated the `bannerTitle` in localization files (`locales/lang/de.ts`, `locales/lang/en.ts`, `locales/lang/es.ts`, `locales/lang/fr.ts`) to announce "Leitlearn Beta" instead of "Leitlearn". [[1]](diffhunk://#diff-d2ba3691080306ae75686932b9d7daddc875db2653f1bf0575798b1b30574780L4-R4) [[2]](diffhunk://#diff-4cc8e640650f6f55388788ba720db4904a12b0b948f731b7bee69a2dd3cd7de6L4-R4) [[3]](diffhunk://#diff-f7dac4eb4b8df9b1a3b12f425e5d528bb597ba5ee47c735affa791b54e7fa5bdL4-R4) [[4]](diffhunk://#diff-cb56b5c86b9a8cfaac06a45e537fda87c6b69ece2c284cfcafce50e66e5c9457L4-R4)

### Style Adjustment:
* Added a `font-size` property to the `em` tag in the `PostContent` styled component to improve text readability.